### PR TITLE
specify snic['id'] for image plane (fixes #21)

### DIFF
--- a/post/create_res_sim_mat.py
+++ b/post/create_res_sim_mat.py
@@ -195,7 +195,7 @@ def extract_image_plane(snic, axes, ele_pos):
     import numpy as np
 
     ele0 = np.min(np.where(axes[0] >= ele_pos))
-    image_plane = np.squeeze(snic[ele0, :, :]).astype(int)
+    image_plane = np.squeeze(snic['id'][ele0, :, :]).astype(int)
 
     return image_plane
 


### PR DESCRIPTION
The image plane that is extract should just contain node IDs, but the
original code simply squeezed snic (sorted node IDs and coordinates),
bringing along 'x', 'y' and 'z' for the ride.  The astype(int) operation
was failing b/c the coordinates do not cleanly map, but I'm not sure why
this hasn't always created issues.  

Fixes #21 