### PR TITLE
fix fname -> fname.strpath

### DIFF
--- a/post/create_res_sim_mat.py
+++ b/post/create_res_sim_mat.py
@@ -98,7 +98,7 @@ def extract_arfi_data(dispout, header, image_plane, disp_comp=2,
                                      disp_slice[:, (disp_comp + 1)].squeeze(),
                                      zdisp)
 
-            # node IDs are not saved after the first timestep in latest disp.dat
+            # node IDs not saved after the first timestep in latest disp.dat
             # files (flagged by legacynodes boolean)
             else:
                 fmt = 'f' * int(timestep_bytes / word_size)

--- a/tests/test_create_disp_dat.py
+++ b/tests/test_create_disp_dat.py
@@ -75,7 +75,7 @@ def test_write_header(tmpdir):
     write_headers(dispout, header)
     dispout.close()
 
-    with open(fname, 'rb') as dispout:
+    with open(fname.strpath, 'rb') as dispout:
         h = struct.unpack('fff', dispout.read(4 * 3))
 
     assert h[0] == 4.0
@@ -99,7 +99,7 @@ def test_write_data(tmpdir):
     process_timestep_data(data, dispout, writenode=True)
     dispout.close()
 
-    with open(fname, 'rb') as f:
+    with open(fname.strpath, 'rb') as f:
         d = struct.unpack(8 * 'f', f.read(4 * 8))
 
     assert d[0] == 0.0


### PR DESCRIPTION
fix failing unit tests that could not find temp file written in `tmfile` fixture directory