### PR TITLE
tukey gauss qsym pml example run.py syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,3 +90,6 @@ See the git commit history for an effective change log pre-v6.3.1
 
 ## v7.3.2
 * add `package_data` to `setup.py` to capture examples and docs in `pip install`
+
+## v7.3.3
+* fix syntax in `examples/tukey_gauss_qsym_pml/run.py`

--- a/README.md
+++ b/README.md
@@ -76,3 +76,4 @@ Please file any bug reports, features requests, etc. using the GitHub
 - Brian Bigler (brian.bigler@duke.edu)
 - Carl Herickhoff (cdh14@duke.edu)
 - Sam Lipman (sll16@duke.edu)
+- Anna Knight (aek27@duke.edu)

--- a/examples/tukey_gauss_qsym_pml/run.py
+++ b/examples/tukey_gauss_qsym_pml/run.py
@@ -33,7 +33,7 @@ bc.apply_pml(pml_elems, face_constraints, edge_constraints)
 
 generate_loads([0.1, 0.1, 0.75], [0.0, 0.0, -1.5], tukey_length=2.5)
 
-system('ls-dyna-d ncpu={} i={}'.format((NTASKS, DYNADECK)))
+system('ls-dyna-d ncpu={} i={}'.format(NTASKS, DYNADECK))
 
 create_disp_dat()
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name='fem',
     packages=['fem', 'fem.mesh', 'fem.post', 'fem.field'],
     package_dir={'fem': '.'},
-    version='7.3.2',
+    version='7.3.3',
     license='Apache v2.0',
     author='Mark Palmeri',
     author_email='mlp6@duke.edu',


### PR DESCRIPTION
Tukey Gauss Qsym PML Example's version of run.py called TASKS and DYNADECK as a tuple because of a double parenthetical when it should be a single. This fixes #72 