### PR TITLE
ADD unit test for specified times in create_res_sim

### DIFF
--- a/tests/test_create_res_sim.py
+++ b/tests/test_create_res_sim.py
@@ -67,6 +67,18 @@ def test_get_t():
     assert t[9] == 0.9
 
 
+def test_get_t_specific_times():
+    """test generation of time vector using user-specified list of times
+    """
+    from fem.post.create_res_sim import __gen_t
+
+    t = __gen_t(0.1, list(range(0, 10)))
+
+    assert len(t) == 10
+    assert t[0] == 0.0
+    assert t[9] == 0.9
+
+
 def test_savemat(tmpdir):
     from fem.post.create_res_sim import run
     from scipy.io import loadmat

--- a/tests/test_create_res_sim.py
+++ b/tests/test_create_res_sim.py
@@ -65,18 +65,13 @@ def test_get_t():
     assert len(t) == 10
     assert t[0] == 0.0
     assert t[9] == 0.9
+    
+    t = __gen_t(0.1, [1, 10, 101]))
 
-
-def test_get_t_specific_times():
-    """test generation of time vector using user-specified list of times
-    """
-    from fem.post.create_res_sim import __gen_t
-
-    t = __gen_t(0.1, list(range(0, 10)))
-
-    assert len(t) == 10
+    assert len(t) == 3
     assert t[0] == 0.0
-    assert t[9] == 0.9
+    assert t[1] == 0.9
+    assert t[2] == 10.0
 
 
 def test_savemat(tmpdir):

--- a/tests/test_create_res_sim.py
+++ b/tests/test_create_res_sim.py
@@ -66,7 +66,7 @@ def test_get_t():
     assert t[0] == 0.0
     assert t[9] == 0.9
     
-    t = __gen_t(0.1, [1, 10, 101]))
+    t = __gen_t(0.1, [1, 10, 101])
 
     assert len(t) == 3
     assert t[0] == 0.0


### PR DESCRIPTION
@fqjin wrote a unit test to just show equivalent function of the list specification for timesteps vs. the previous default of just passing in an int to represent the total number of timesteps.  Right now, it appears that the input specification is not consistent.  Can you look at the failing test and see if I'm misinterpreting the way it should work?

Issue #114 